### PR TITLE
Use always full path when validating openapi

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -1,8 +1,10 @@
+const { resolve } = require('path');
 const { loadAndBundleSpec } = require('redoc');
 
 const validate = async function (pathToSpec) {
   try {
-    await loadAndBundleSpec(pathToSpec);
+    const fullPath = resolve(pathToSpec);
+    await loadAndBundleSpec(fullPath);
     return undefined;
   } catch (error) {
     return error.message;

--- a/validate.test.js
+++ b/validate.test.js
@@ -1,12 +1,11 @@
 const validate = require('./validate');
 
-const fixturePath = `${__dirname}/fixtures`;
 test('validates valid openapi file', async () => {
-  return expect(validate(`${fixturePath}/valid_openapi.yml`)).resolves.toEqual(undefined);
+  return expect(validate('fixtures/valid_openapi.yml')).resolves.toEqual(undefined);
 });
 
 test('validates invalid openapi file', async () => {
-  return expect(validate(`${fixturePath}/invalid_openapi.yml`)).resolves.toContain(
+  return expect(validate('fixtures/invalid_openapi.yml')).resolves.toContain(
     'Cannot read properties'
   );
 });


### PR DESCRIPTION
The redoc 2.0 doesn't work with relative paths anymore. Convert the relative path to full path before validating the openapi file.