### PR TITLE
Build dist before testing action

### DIFF
--- a/.github/templates/jobs/test_action.erb
+++ b/.github/templates/jobs/test_action.erb
@@ -7,6 +7,8 @@ test_action:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
+    - name: yarn install
+      run: yarn install
     - name: Build distribution
       run: yarn clean && yarn dist
     - name: Validate valid openapi file

--- a/.github/templates/jobs/test_action.erb
+++ b/.github/templates/jobs/test_action.erb
@@ -7,6 +7,8 @@ test_action:
       uses: actions/setup-node@v3
       with:
         node-version: 16.x
+    - name: Build distribution
+      run: yarn clean && yarn dist
     - name: Validate valid openapi file
       uses: ./
       with:

--- a/.github/workflows/pull_request.generated.yml
+++ b/.github/workflows/pull_request.generated.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
+      - name: Build distribution
+        run: yarn clean && yarn dist
       - name: Validate valid openapi file
         uses: ./
         with:

--- a/.github/workflows/pull_request.generated.yml
+++ b/.github/workflows/pull_request.generated.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
+      - name: yarn install
+        run: yarn install
       - name: Build distribution
         run: yarn clean && yarn dist
       - name: Validate valid openapi file

--- a/.github/workflows/release.generated.yml
+++ b/.github/workflows/release.generated.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
+      - name: Build distribution
+        run: yarn clean && yarn dist
       - name: Validate valid openapi file
         uses: ./
         with:

--- a/.github/workflows/release.generated.yml
+++ b/.github/workflows/release.generated.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
+      - name: yarn install
+        run: yarn install
       - name: Build distribution
         run: yarn clean && yarn dist
       - name: Validate valid openapi file


### PR DESCRIPTION
We released non working action since the `test action` GHA that verifies that the action actually works was using the previously built `dist` folder.

To fix the issue, build the new distribution with the PR's code before running the action.