### PR TITLE
Bump node version in action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: true
     default: 'openapi/openapi.yml'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Bump node version to 20 as Node.js 16 actions are deprecated.